### PR TITLE
docs(fs5.5): sync latest release snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Zig runtime port of OpenClaw with parity-first delivery, deterministic validatio
 - RPC method surface in Zig: `175`
 - Pinned parity gate (tri-baseline, CI/docs):
   - Go baseline (`v2.14.0-go`): `134/134` covered
-  - Original OpenClaw baseline (`v2026.3.8`): `97/97` covered
-  - Original OpenClaw beta baseline (`v2026.3.8-beta.1`): `97/97` covered
-  - Union baseline: `138/138` covered (`MISSING_IN_ZIG=0`)
+  - Original OpenClaw baseline (`v2026.3.11`): `99/99` covered
+  - Original OpenClaw beta baseline (`v2026.3.11-beta.1`): `99/99` covered
+  - Union baseline: `140/140` covered (`MISSING_IN_ZIG=0`)
   - Gateway events: stable `19/19`, beta `19/19`, union `19/19` (`UNION_EVENTS_MISSING_IN_ZIG=0`)
 - Latest upstream release snapshot (docs drift gate reference):
-  - Original OpenClaw baseline (`v2026.3.8`): `97/97` covered
-  - Original OpenClaw beta baseline (`v2026.3.8-beta.1`): `97/97` covered
-  - Union baseline: `138/138` covered (`MISSING_IN_ZIG=0`)
+  - Original OpenClaw baseline (`v2026.3.11`): `99/99` covered
+  - Original OpenClaw beta baseline (`v2026.3.11-beta.1`): `99/99` covered
+  - Union baseline: `140/140` covered (`MISSING_IN_ZIG=0`)
 - Latest local validation: `zig build test --summary all` -> main `292/292` + bare-metal host `253/253` passing
 - Latest published edge release tag: `v0.2.0-zig-edge.28`
 - Toolchain policy: Codeberg `master` is canonical; `adybag14-cyber/zig` publishes rolling `latest-master` and immutable `upstream-<sha>` Windows releases for refresh and reproducibility.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,14 +7,14 @@ Full documentation for the OpenClaw Zig runtime port.
 - RPC surface in Zig: `175` methods
 - Pinned tri-baseline parity gate:
   - Go baseline (`v2.14.0-go`): `134/134`
-  - Original OpenClaw baseline (`v2026.3.8`): `97/97`
-  - Original OpenClaw beta baseline (`v2026.3.8-beta.1`): `97/97`
-  - Union baseline: `138/138` (`MISSING_IN_ZIG=0`)
+  - Original OpenClaw baseline (`v2026.3.11`): `99/99`
+  - Original OpenClaw beta baseline (`v2026.3.11-beta.1`): `99/99`
+  - Union baseline: `140/140` (`MISSING_IN_ZIG=0`)
   - Gateway events union baseline: `19/19` (`UNION_EVENTS_MISSING_IN_ZIG=0`)
 - Latest upstream release snapshot (docs drift gate reference):
-  - Original OpenClaw baseline (`v2026.3.8`): `97/97`
-  - Original OpenClaw beta baseline (`v2026.3.8-beta.1`): `97/97`
-  - Union baseline: `138/138` (`MISSING_IN_ZIG=0`)
+  - Original OpenClaw baseline (`v2026.3.11`): `99/99`
+  - Original OpenClaw beta baseline (`v2026.3.11-beta.1`): `99/99`
+  - Union baseline: `140/140` (`MISSING_IN_ZIG=0`)
 - Latest local validation: `292/292` main tests + `253/253` bare-metal host tests passing
 - Latest published edge release tag: `v0.2.0-zig-edge.28`
 - Toolchain lane: Codeberg `master` is canonical; `adybag14-cyber/zig` provides rolling `latest-master` and immutable `upstream-<sha>` Windows releases for refresh and reproducibility.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated baseline version references from v2026.3.8 to v2026.3.11 in documentation
  * Updated coverage metrics across baseline and union categories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->