### PR TITLE
chore(release): bump package clients to edge.29

### DIFF
--- a/npm/openclaw-zig-rpc-client/README.md
+++ b/npm/openclaw-zig-rpc-client/README.md
@@ -11,7 +11,7 @@ npm install @adybag14-cyber/openclaw-zig-rpc-client
 GitHub release tarball fallback for the current edge tag:
 
 ```bash
-npm install "https://github.com/adybag14-cyber/openclaw-zig-port/releases/download/v0.2.0-zig-edge.28/adybag14-cyber-openclaw-zig-rpc-client-0.2.0-zig-edge.28.tgz"
+npm install "https://github.com/adybag14-cyber/openclaw-zig-port/releases/download/v0.2.0-zig-edge.29/adybag14-cyber-openclaw-zig-rpc-client-0.2.0-zig-edge.29.tgz"
 ```
 
 ## Usage

--- a/npm/openclaw-zig-rpc-client/package.json
+++ b/npm/openclaw-zig-rpc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adybag14-cyber/openclaw-zig-rpc-client",
-  "version": "0.2.0-zig-edge.28",
+  "version": "0.2.0-zig-edge.29",
   "description": "Node.js RPC client for OpenClaw Zig gateway endpoints.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/python/openclaw-zig-rpc-client/README.md
+++ b/python/openclaw-zig-rpc-client/README.md
@@ -11,7 +11,7 @@ pip install openclaw-zig-rpc-client
 Release-wheel fallback:
 
 ```bash
-pip install "https://github.com/adybag14-cyber/openclaw-zig-port/releases/download/v0.2.0-zig-edge.28/openclaw_zig_rpc_client-0.2.0.dev28-py3-none-any.whl"
+pip install "https://github.com/adybag14-cyber/openclaw-zig-port/releases/download/v0.2.0-zig-edge.29/openclaw_zig_rpc_client-0.2.0.dev29-py3-none-any.whl"
 ```
 
 Run directly with `uvx` after publishing:
@@ -23,7 +23,7 @@ uvx --from openclaw-zig-rpc-client openclaw-zig-rpc health --base-url http://127
 Verified `uvx` Git fallback for the current edge tag:
 
 ```bash
-uvx --from "git+https://github.com/adybag14-cyber/openclaw-zig-port@v0.2.0-zig-edge.28#subdirectory=python/openclaw-zig-rpc-client" openclaw-zig-rpc health --base-url http://127.0.0.1:8080
+uvx --from "git+https://github.com/adybag14-cyber/openclaw-zig-port@v0.2.0-zig-edge.29#subdirectory=python/openclaw-zig-rpc-client" openclaw-zig-rpc health --base-url http://127.0.0.1:8080
 ```
 
 ## Python Usage

--- a/python/openclaw-zig-rpc-client/pyproject.toml
+++ b/python/openclaw-zig-rpc-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openclaw-zig-rpc-client"
-version = "0.2.0.dev28"
+version = "0.2.0.dev29"
 description = "Python JSON-RPC client for OpenClaw Zig gateway endpoints."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package versions from edge.28 to edge.29 for both npm and Python clients
  * Updated fallback URLs and installation references to reflect the new edge release versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->