### PR TITLE
docs(release): sync edge.29 package status

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Zig runtime port of OpenClaw with parity-first delivery, deterministic validatio
   - Original OpenClaw beta baseline (`v2026.3.11-beta.1`): `99/99` covered
   - Union baseline: `140/140` covered (`MISSING_IN_ZIG=0`)
 - Latest local validation: `zig build test --summary all` -> main `292/292` + bare-metal host `253/253` passing
-- Latest published edge release tag: `v0.2.0-zig-edge.28`
+- Latest published edge release tag: `v0.2.0-zig-edge.29`
 - Toolchain policy: Codeberg `master` is canonical; `adybag14-cyber/zig` publishes rolling `latest-master` and immutable `upstream-<sha>` Windows releases for refresh and reproducibility.
 - CI policy: keep hosted build/test/parity/docs on Zig `master`, but pin the freestanding bare-metal compile/probe lane to the known-good Linux build `0.16.0-dev.2736+3b515fbed` until the upstream Linux `master` compiler crash on `zig build baremetal -Doptimize=ReleaseFast` is resolved.
 - Recent FS1 progress (2026-03-06):

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Full documentation for the OpenClaw Zig runtime port.
   - Original OpenClaw beta baseline (`v2026.3.11-beta.1`): `99/99`
   - Union baseline: `140/140` (`MISSING_IN_ZIG=0`)
 - Latest local validation: `292/292` main tests + `253/253` bare-metal host tests passing
-- Latest published edge release tag: `v0.2.0-zig-edge.28`
+- Latest published edge release tag: `v0.2.0-zig-edge.29`
 - Toolchain lane: Codeberg `master` is canonical; `adybag14-cyber/zig` provides rolling `latest-master` and immutable `upstream-<sha>` Windows releases for refresh and reproducibility.
 - Recent FS1 progress (2026-03-06):
   - runtime recovery posture surfaced in `status`, `doctor`, `doctor.memory.status`, `agent.identity.get`, and maintenance RPCs

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,7 +2,7 @@
 
 ## Current Snapshot
 
-- Latest published edge release: `v0.2.0-zig-edge.28`
+- Latest published edge release: `v0.2.0-zig-edge.29`
 - Latest local test gate: `zig build test --summary all` -> main `292/292` + bare-metal host `253/253` passing
 - Latest parity gate: `scripts/check-go-method-parity.ps1` -> `GO_MISSING_IN_ZIG=0`, `ORIGINAL_MISSING_IN_ZIG=0`, `ORIGINAL_BETA_MISSING_IN_ZIG=0`, `UNION_MISSING_IN_ZIG=0`, `UNION_EVENTS_MISSING_IN_ZIG=0`, `ZIG_COUNT=175`, `ZIG_EVENTS_COUNT=19`
 - Current head: local source-of-truth on `fs55-ethernet-integration` (exact pushed head is tracked in issue `#1` and the latest branch GitHub Actions runs)

--- a/docs/package-publishing.md
+++ b/docs/package-publishing.md
@@ -8,9 +8,9 @@ This repo ships three package-consumption paths for the Zig RPC client surfaces:
 
 ## Current Edge Release
 
-- GitHub prerelease tag: `v0.2.0-zig-edge.28`
-- npm package version: `0.2.0-zig-edge.28`
-- Python package version: `0.2.0.dev28`
+- GitHub prerelease tag: `v0.2.0-zig-edge.29`
+- npm package version: `0.2.0-zig-edge.29`
+- Python package version: `0.2.0.dev29`
 
 ## Install Paths
 
@@ -19,13 +19,13 @@ This repo ships three package-consumption paths for the Zig RPC client surfaces:
 Preferred when npmjs is configured:
 
 ```bash
-npm install @adybag14-cyber/openclaw-zig-rpc-client@0.2.0-zig-edge.28
+npm install @adybag14-cyber/openclaw-zig-rpc-client@0.2.0-zig-edge.29
 ```
 
 Fallback from the GitHub release tarball:
 
 ```bash
-npm install "https://github.com/adybag14-cyber/openclaw-zig-port/releases/download/v0.2.0-zig-edge.28/adybag14-cyber-openclaw-zig-rpc-client-0.2.0-zig-edge.28.tgz"
+npm install "https://github.com/adybag14-cyber/openclaw-zig-port/releases/download/v0.2.0-zig-edge.29/adybag14-cyber-openclaw-zig-rpc-client-0.2.0-zig-edge.29.tgz"
 ```
 
 ### pip
@@ -33,13 +33,13 @@ npm install "https://github.com/adybag14-cyber/openclaw-zig-port/releases/downlo
 Preferred when PyPI is configured:
 
 ```bash
-pip install openclaw-zig-rpc-client==0.2.0.dev28
+pip install openclaw-zig-rpc-client==0.2.0.dev29
 ```
 
 Fallback from the GitHub release wheel:
 
 ```bash
-pip install "https://github.com/adybag14-cyber/openclaw-zig-port/releases/download/v0.2.0-zig-edge.28/openclaw_zig_rpc_client-0.2.0.dev28-py3-none-any.whl"
+pip install "https://github.com/adybag14-cyber/openclaw-zig-port/releases/download/v0.2.0-zig-edge.29/openclaw_zig_rpc_client-0.2.0.dev29-py3-none-any.whl"
 ```
 
 ### uvx
@@ -53,7 +53,7 @@ uvx --from openclaw-zig-rpc-client openclaw-zig-rpc health --base-url http://127
 Git fallback verified locally against the release tag:
 
 ```bash
-uvx --from "git+https://github.com/adybag14-cyber/openclaw-zig-port@v0.2.0-zig-edge.28#subdirectory=python/openclaw-zig-rpc-client" openclaw-zig-rpc health --base-url http://127.0.0.1:8080
+uvx --from "git+https://github.com/adybag14-cyber/openclaw-zig-port@v0.2.0-zig-edge.29#subdirectory=python/openclaw-zig-rpc-client" openclaw-zig-rpc health --base-url http://127.0.0.1:8080
 ```
 
 ## Registry Configuration Requirements
@@ -67,12 +67,14 @@ The workflow supports two public-publish paths:
 
 If neither public path succeeds, the workflow falls back to GitHub Packages and still attaches the tarball to the GitHub release.
 
-Current blocker observed during `v0.2.0-zig-edge.28`:
+Current state observed during `v0.2.0-zig-edge.29`:
 
-- npmjs trusted publishing reached npmjs and emitted signed provenance
-- npmjs then returned `404 Not Found` for `@adybag14-cyber/openclaw-zig-rpc-client`
+- `npm-release` completed successfully
+- the tarball was attached to the GitHub prerelease
+- the GitHub Packages fallback path executed successfully
+- public npmjs visibility for `@adybag14-cyber/openclaw-zig-rpc-client@0.2.0-zig-edge.29` still returns `404 Not Found`
 
-That means the npm side still needs one of:
+That means the public npmjs side still needs one of:
 
 1. the `@adybag14-cyber` scope/package provisioned on npmjs with publish permission for this repo/workflow
 2. a valid `NPM_TOKEN` configured in repo secrets
@@ -90,9 +92,12 @@ The workflow supports two public-publish paths:
 
 If neither public path succeeds, the workflow still attaches the wheel and sdist to the GitHub release.
 
-Current blocker observed during `v0.2.0-zig-edge.28`:
+Current state observed during `v0.2.0-zig-edge.29`:
 
-- trusted publishing failed with `invalid-publisher`
+- `python-release` completed successfully
+- the wheel and sdist were attached to the GitHub prerelease
+- public PyPI visibility for `openclaw-zig-rpc-client==0.2.0.dev29` still returns `404 Not Found`
+- trusted publishing still fails with `invalid-publisher`
 
 That means PyPI does not yet have a matching trusted publisher entry for:
 
@@ -101,14 +106,14 @@ That means PyPI does not yet have a matching trusted publisher entry for:
 - ref: `refs/heads/main`
 - environment: `pypi`
 
-Exact claims emitted by the latest trusted-publish attempt (`python-release` run `22749787597`):
+Exact claims emitted by the latest trusted-publish attempt (`python-release` run `23109251947`):
 
 - `sub`: `repo:adybag14-cyber/openclaw-zig-port:environment:pypi`
 - `repository`: `adybag14-cyber/openclaw-zig-port`
 - `repository_owner`: `adybag14-cyber`
-- `workflow_ref`: `adybag14-cyber/openclaw-zig-port/.github/workflows/python-release.yml@refs/heads/main`
-- `job_workflow_ref`: `adybag14-cyber/openclaw-zig-port/.github/workflows/python-release.yml@refs/heads/main`
-- `ref`: `refs/heads/main`
+- `workflow_ref`: `adybag14-cyber/openclaw-zig-port/.github/workflows/python-release.yml@refs/heads/fs55-ethernet-integration`
+- `job_workflow_ref`: `adybag14-cyber/openclaw-zig-port/.github/workflows/python-release.yml@refs/heads/fs55-ethernet-integration`
+- `ref`: `refs/heads/fs55-ethernet-integration`
 - `environment`: `pypi`
 
 Fix either by:
@@ -140,11 +145,11 @@ Local/operator check:
 
 ```powershell
 pwsh ./scripts/package-registry-status.ps1 `
-  -ReleaseTag v0.2.0-zig-edge.28 `
+  -ReleaseTag v0.2.0-zig-edge.29 `
   -NpmPackageName @adybag14-cyber/openclaw-zig-rpc-client `
-  -NpmVersion 0.2.0-zig-edge.28 `
+  -NpmVersion 0.2.0-zig-edge.29 `
   -PythonPackageName openclaw-zig-rpc-client `
-  -PythonVersion 0.2.0.dev28 `
+  -PythonVersion 0.2.0.dev29 `
   -OutputJsonPath ./release/package-registry-status.json
 ```
 
@@ -161,7 +166,7 @@ Local/operator snapshot:
 
 ```powershell
 pwsh ./scripts/release-status.ps1 `
-  -ReleaseTag v0.2.0-zig-edge.28 `
+  -ReleaseTag v0.2.0-zig-edge.29 `
   -OutputJsonPath ./release/release-status.json `
   -OutputMarkdownPath ./release/release-status.md
 ```

--- a/docs/zig-port/FULL_STACK_REPLACEMENT_MATRIX.md
+++ b/docs/zig-port/FULL_STACK_REPLACEMENT_MATRIX.md
@@ -11,7 +11,7 @@ Master tracking:
 | Baseline | Ref Type | Value | Status |
 |---|---|---|---|
 | OpenClaw Zig Port | Commit | `caaedd9` | Locked |
-| OpenClaw Zig Port | Release | `v0.2.0-zig-edge.28` | Locked |
+| OpenClaw Zig Port | Release | `v0.2.0-zig-edge.29` | Locked |
 | OpenClaw Go Port | Release/Commit | `v2.14.0-go @ 3614cf457cf26220e486d7f3dc8df09353b38a32` | Locked |
 | OpenClaw Rust Port | Release/Commit | `v1.7.15 @ b2abb0d1fa747e371a53ea0890ffd80e4e29ea79` | Locked |
 | Original OpenClaw Stable | Release/Commit | `v2026.3.2 @ 85377a28175695c224f6589eb5c1460841ecd65c` | Locked |

--- a/docs/zig-port/PHASE_CHECKLIST.md
+++ b/docs/zig-port/PHASE_CHECKLIST.md
@@ -2,7 +2,7 @@
 
 Release lock: no release tag is allowed until all phases are complete and parity is measured at 100%.
 Historical note: milestone validation counts below are preserved as captured at the time of each slice; current project-wide test gate is refreshed after each strict hosted-phase signoff.
-Latest edge release: `v0.2.0-zig-edge.28` is published with binaries, parity evidence, SBOM/provenance, npm tarball, wheel, and sdist attached.
+Latest edge release: `v0.2.0-zig-edge.29` is published with binaries, parity evidence, SBOM/provenance, npm tarball, wheel, and sdist attached.
 Registry status:
 - npm public publish still requires npm-side scope/package permission or `NPM_TOKEN`; GitHub release asset + GitHub Packages fallback are available now.
 - PyPI public publish still requires a matching trusted publisher or `PYPI_API_TOKEN`; workflow claim shape is now confirmed as `repo:adybag14-cyber/openclaw-zig-port:environment:pypi`.

--- a/docs/zig-port/PORT_PLAN.md
+++ b/docs/zig-port/PORT_PLAN.md
@@ -208,7 +208,7 @@ Full-stack replacement execution reference:
     - browser-session auth, browser completion success, and Telegram command/reply proofs are green locally
     - FS2 strict closure is now reached locally: provider/session auth, browser completion, direct-provider completion, Telegram reply-loop, Telegram webhook ingress, and Telegram bot-send delivery all have dedicated proofs
   - Release/package lane status (2026-03-06):
-  - GitHub prerelease `v0.2.0-zig-edge.28` is live with desktop/android/bare-metal artifacts, parity reports, manifest, SBOM, provenance, npm tarball, wheel, and sdist.
+  - GitHub prerelease `v0.2.0-zig-edge.29` is live with desktop/android/bare-metal artifacts, parity reports, manifest, SBOM, provenance, npm tarball, wheel, and sdist.
   - release evidence now also includes `release-status.json` + `release-status.md` so every edge cut carries a frozen workflow-status + registry-status snapshot in addition to package preflight evidence.
   - Zig toolchain evidence is now mirror-aware:
     - `scripts/zig-github-mirror-release-check.ps1` snapshots the `adybag14-cyber/zig` release target commitish, Windows asset URL, and SHA256 digest.
@@ -222,13 +222,13 @@ Full-stack replacement execution reference:
     - freestanding bare-metal smoke/probe validation and `build-baremetal-asset` are pinned to the known-good Linux build `0.16.0-dev.2736+3b515fbed`.
     - reason: current upstream Linux `master` can segfault on `zig build baremetal -Doptimize=ReleaseFast` even though the pinned Linux `0.16.0-dev.2736+3b515fbed` bare-metal lane validates cleanly.
   - `uvx` fallback from the tagged Git repo was validated locally:
-    - `uvx --from "git+https://github.com/adybag14-cyber/openclaw-zig-port@v0.2.0-zig-edge.28#subdirectory=python/openclaw-zig-rpc-client" openclaw-zig-rpc --help`
-  - npm public publish remains externally blocked by npm scope/package permission on npmjs; GitHub Packages fallback remains available.
+    - `uvx --from "git+https://github.com/adybag14-cyber/openclaw-zig-port@v0.2.0-zig-edge.29#subdirectory=python/openclaw-zig-rpc-client" openclaw-zig-rpc --help`
+  - npm public publish remains externally blocked by npm scope/package permission on npmjs; the edge.29 tarball is attached to the GitHub prerelease and the GitHub Packages fallback path ran successfully.
   - `scripts/package-registry-status.ps1` now uses the resolved default npm/PyPI package names when called with only `-ReleaseTag`, so local release diagnostics correctly report public-registry 404 state instead of silently skipping those checks.
-  - PyPI public publish remains externally blocked by missing trusted-publisher mapping, but the workflow now emits the confirmed OIDC claim shape:
+  - PyPI public publish remains externally blocked by missing trusted-publisher mapping, but the workflow now emits the confirmed OIDC claim shape for the branch release lane:
     - `sub=repo:adybag14-cyber/openclaw-zig-port:environment:pypi`
-    - `workflow_ref=adybag14-cyber/openclaw-zig-port/.github/workflows/python-release.yml@refs/heads/main`
-    - `ref=refs/heads/main`
+    - `workflow_ref=adybag14-cyber/openclaw-zig-port/.github/workflows/python-release.yml@refs/heads/fs55-ethernet-integration`
+    - `ref=refs/heads/fs55-ethernet-integration`
   - FS1 runtime persistence posture slice shipped:
     - `security.audit` now emits `runtime.state_path.in_memory` when state is empty or memory-backed.
     - `doctor` now exposes `runtime.state_path` and `security.policy_bundle` checks with explicit persisted-vs-memory detail.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release version references to the latest edge build (v0.2.0-zig-edge.29) across documentation files.
  * Expanded phase checklists and port plan documentation with additional testing scope, validation gates, and subsystem coverage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->