### PR TITLE
fix(ci): align android bench build policy

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -56,6 +56,12 @@ pub fn build(b: *std.Build) void {
     if (target.result.os.tag == .windows) {
         benchmark_module.strip = true;
     }
+    if (target.result.os.tag == .linux and target.result.abi.isAndroid() and target.result.cpu.arch == .arm) {
+        // Keep the benchmark binary on the same single-threaded Android ARM policy as
+        // the main runtime binary so ReleaseFast cross-target builds do not pull in
+        // TLS runtime linkage that currently fails under the pinned Zig lane.
+        benchmark_module.single_threaded = true;
+    }
 
     const exe = b.addExecutable(.{
         .name = "openclaw-zig",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized benchmark build configuration for Android ARM targets to enable single-threaded mode, ensuring consistency with the main runtime behavior across this platform combination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->