### PR TITLE
feat(fs5.7): add initial i386 baremetal architecture proof

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -183,9 +183,17 @@ jobs:
         shell: pwsh
         run: ./scripts/baremetal-smoke-check.ps1
 
+      - name: Bare-metal i386 smoke check (freestanding build)
+        shell: pwsh
+        run: ./scripts/baremetal-i386-smoke-check.ps1
+
       - name: Bare-metal QEMU smoke check (optional)
         shell: pwsh
         run: ./scripts/baremetal-qemu-smoke-check.ps1 -SkipBuild
+
+      - name: Bare-metal QEMU i386 smoke check (optional)
+        shell: pwsh
+        run: ./scripts/baremetal-qemu-i386-smoke-check.ps1
 
       - name: Bare-metal QEMU runtime probe (optional)
         shell: pwsh

--- a/.github/workflows/zig-ci.yml
+++ b/.github/workflows/zig-ci.yml
@@ -157,9 +157,17 @@ jobs:
         shell: pwsh
         run: ./scripts/baremetal-smoke-check.ps1
 
+      - name: Bare-metal i386 smoke check (freestanding build)
+        shell: pwsh
+        run: ./scripts/baremetal-i386-smoke-check.ps1
+
       - name: Bare-metal QEMU smoke check (optional)
         shell: pwsh
         run: ./scripts/baremetal-qemu-smoke-check.ps1 -SkipBuild
+
+      - name: Bare-metal QEMU i386 smoke check (optional)
+        shell: pwsh
+        run: ./scripts/baremetal-qemu-i386-smoke-check.ps1
 
       - name: Bare-metal QEMU runtime probe (optional)
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ZAR-Zig-Agent-Runtime is the Zig runtime port of OpenClaw, with parity-first del
 - Latest local validation: `zig build test --summary all` -> hosted `480/480`, bare-metal host `484 passed / 1 skipped`
 - Current edge release target tag: `v0.2.0-zig-edge.31`
 - License posture: repo-wide `GPL-2.0-only` with Linux-style SPDX headers on repo-owned source and script files
+- `FS5.7` i386 CPU-architecture support is now started and tracked in [`docs/zig-port/FS5_7_I386_CPU_ARCHITECTURE.md`](docs/zig-port/FS5_7_I386_CPU_ARCHITECTURE.md), with a real `x86-freestanding-none` artifact emitted by `zig build baremetal-i386` plus hosted and live QEMU smoke gates through `scripts/baremetal-i386-smoke-check.ps1` and `scripts/baremetal-qemu-i386-smoke-check.ps1`
 - Toolchain policy: Codeberg `master` is canonical; `adybag14-cyber/zig` publishes rolling `latest-master` and immutable `upstream-<sha>` Windows releases for refresh and reproducibility.
 - CI policy: keep hosted build/test/parity/docs on Zig `master`, but pin the freestanding bare-metal compile/probe lane to the known-good Linux build `0.16.0-dev.2736+3b515fbed` until the upstream Linux `master` compiler crash on `zig build baremetal -Doptimize=ReleaseFast` is resolved.
 - Recent FS1 progress (2026-03-06):

--- a/build.zig
+++ b/build.zig
@@ -154,16 +154,6 @@ pub fn build(b: *std.Build) void {
     } else b.addRunArtifact(benchmark_tests);
     test_step.dependOn(&run_benchmark_tests.step);
 
-    const baremetal_target = b.resolveTargetQuery(.{
-        .cpu_arch = .x86_64,
-        .os_tag = .freestanding,
-        .abi = .none,
-    });
-    const baremetal_module = b.createModule(.{
-        .root_source_file = b.path("src/baremetal_main.zig"),
-        .target = baremetal_target,
-        .optimize = optimize,
-    });
     const baremetal_options = b.addOptions();
     baremetal_options.addOption(bool, "qemu_smoke", baremetal_qemu_smoke);
     baremetal_options.addOption(bool, "console_probe_banner", baremetal_console_probe_banner);
@@ -210,6 +200,16 @@ pub fn build(b: *std.Build) void {
     baremetal_options.addOption(bool, "rtl8139_runtime_service_probe", baremetal_rtl8139_runtime_service_probe);
     baremetal_options.addOption(bool, "tool_exec_probe", baremetal_tool_exec_probe);
     baremetal_options.addOption(bool, "tool_runtime_probe", baremetal_tool_runtime_probe);
+    const baremetal_target = b.resolveTargetQuery(.{
+        .cpu_arch = .x86_64,
+        .os_tag = .freestanding,
+        .abi = .none,
+    });
+    const baremetal_module = b.createModule(.{
+        .root_source_file = b.path("src/baremetal_main.zig"),
+        .target = baremetal_target,
+        .optimize = optimize,
+    });
     baremetal_module.addOptions("build_options", baremetal_options);
     baremetal_module.single_threaded = true;
     baremetal_module.strip = false;
@@ -229,4 +229,31 @@ pub fn build(b: *std.Build) void {
     });
     const baremetal_step = b.step("baremetal", "Build freestanding bare-metal runtime image");
     baremetal_step.dependOn(&install_baremetal.step);
+
+    const baremetal_i386_target = b.resolveTargetQuery(.{
+        .cpu_arch = .x86,
+        .os_tag = .freestanding,
+        .abi = .none,
+    });
+    const baremetal_i386_module = b.createModule(.{
+        .root_source_file = b.path("src/baremetal_main.zig"),
+        .target = baremetal_i386_target,
+        .optimize = optimize,
+    });
+    baremetal_i386_module.addOptions("build_options", baremetal_options);
+    baremetal_i386_module.single_threaded = true;
+    baremetal_i386_module.strip = false;
+    baremetal_i386_module.addAssemblyFile(b.path("scripts/baremetal/i386_boot.S"));
+
+    const baremetal_i386_exe = b.addExecutable(.{
+        .name = "openclaw-zig-baremetal-i386",
+        .root_module = baremetal_i386_module,
+    });
+    baremetal_i386_exe.link_gc_sections = false;
+    baremetal_i386_exe.setLinkerScript(b.path("scripts/baremetal/i386_lld.ld"));
+    const install_baremetal_i386 = b.addInstallArtifact(baremetal_i386_exe, .{
+        .dest_sub_path = "openclaw-zig-baremetal-i386.elf",
+    });
+    const baremetal_i386_step = b.step("baremetal-i386", "Build freestanding i386 bare-metal runtime image");
+    baremetal_i386_step.dependOn(&install_baremetal_i386.step);
 }

--- a/docs/zig-port/FS5_7_I386_CPU_ARCHITECTURE.md
+++ b/docs/zig-port/FS5_7_I386_CPU_ARCHITECTURE.md
@@ -1,0 +1,42 @@
+# FS5.7 i386 CPU Architecture Support
+
+## Scope
+
+Start `FS5.7` with a real bounded `i386` freestanding lane, without falsely claiming full 32-bit parity for the existing `x86_64` driver/runtime matrix.
+
+## First Delivered Slice
+
+- `build.zig` now emits a second freestanding artifact:
+  - `zig build baremetal-i386`
+  - output: `zig-out/bin/openclaw-zig-baremetal-i386.elf`
+- new 32-bit bootstrap path:
+  - `scripts/baremetal/i386_boot.S`
+  - `scripts/baremetal/i386_lld.ld`
+- new validation:
+  - `scripts/baremetal-i386-smoke-check.ps1`
+  - `scripts/baremetal-qemu-i386-smoke-check.ps1`
+- hosted CI and `release-preview` now execute both i386 checks.
+
+## What This Proves
+
+- the freestanding runtime builds for `x86-freestanding-none`
+- the emitted artifact is `ELF32`
+- the artifact keeps the required Multiboot2 header
+- the artifact carries the PVH ELF note required by the current direct QEMU `-kernel` path
+- `qemu-system-i386` boots the artifact far enough to reach `baremetalStart()` and exit through the existing `isa-debug-exit` smoke path
+
+## Current Boundary
+
+- this is build/boot smoke plus direct-QEMU entry proof
+- it is not yet full 32-bit driver/runtime parity
+- no live `i386` NIC/storage/display probe lanes are claimed yet
+- `src/baremetal/x86_bootstrap.zig` still carries the current `x86_64` descriptor-table layout and needs an explicit `i386` follow-up
+
+## Next Steps
+
+1. make the bootstrap/descriptor seam dual-arch instead of implicitly `x86_64`
+2. classify each freestanding subsystem into:
+   - already 32-bit-safe
+   - safe after guard widening
+   - still blocked on `x86_64` assumptions
+3. ship the first bounded live `i386` subsystem proof beyond smoke

--- a/docs/zig-port/PHASE_CHECKLIST.md
+++ b/docs/zig-port/PHASE_CHECKLIST.md
@@ -9,6 +9,7 @@ Registry status:
 - `scripts/package-registry-status.ps1` now checks public npmjs/PyPI visibility correctly even when called with only `-ReleaseTag`, so local release diagnostics no longer silently skip the unresolved registry state.
 - release evidence now also includes `release-status.json` + `release-status.md`, which snapshot package visibility plus the latest `zig-ci` / `docs-pages` / `release-preview` / `npm-release` / `python-release` workflow state for the target tag.
 - `FS5.6` repo-wide license refresh is now strict-closed locally: root/package license files, release evidence, package metadata, and Linux-style SPDX headers now use `GPL-2.0-only` to match the Linux-derived RTL8139 slice.
+- `FS5.7` i386 CPU-architecture support is now started and tracked in `docs/zig-port/FS5_7_I386_CPU_ARCHITECTURE.md`; the first delivered slice emits a real `zig build baremetal-i386` freestanding `x86-freestanding-none` artifact through `scripts/baremetal/i386_boot.S` + `scripts/baremetal/i386_lld.ld`, validates `ELF32` + Multiboot2 header retention through `scripts/baremetal-i386-smoke-check.ps1`, and proves live QEMU boot to `baremetalStart()` plus `isa-debug-exit` through `scripts/baremetal-qemu-i386-smoke-check.ps1`.
 - ZigOS integration planning is now tracked in:
   - `docs/zig-port/ZAR_VS_ZIGOS_INTEGRATION_PLAN.md`
   - `docs/zig-port/ZAR_VS_ZIGOS_E1000_SLICE_PLAN.md`

--- a/docs/zig-port/PORT_PLAN.md
+++ b/docs/zig-port/PORT_PLAN.md
@@ -10,6 +10,11 @@ Track and achieve OpenClaw Zig parity against upstream stable + beta baselines:
 while maintaining parity-first validation and release gating.
 
 Full-stack replacement execution reference:
+- `FS5.7` i386 CPU-architecture support is now tracked in:
+  - `docs/zig-port/FS5_7_I386_CPU_ARCHITECTURE.md`
+  - first delivered slice emits a real `zig build baremetal-i386` freestanding `x86-freestanding-none` artifact through `scripts/baremetal/i386_boot.S` + `scripts/baremetal/i386_lld.ld`
+  - validation now includes `scripts/baremetal-i386-smoke-check.ps1` and `scripts/baremetal-qemu-i386-smoke-check.ps1`
+  - current boundary is explicit: this is boot/build smoke plus direct-QEMU entry proof, not full 32-bit driver/runtime parity
 - ZigOS integration planning is now tracked in:
   - `docs/zig-port/ZAR_VS_ZIGOS_INTEGRATION_PLAN.md`
   - `docs/zig-port/ZAR_VS_ZIGOS_E1000_SLICE_PLAN.md`

--- a/scripts/baremetal-i386-smoke-check.ps1
+++ b/scripts/baremetal-i386-smoke-check.ps1
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: GPL-2.0-only
+param(
+    [switch] $SkipBuild
+)
+
+$ErrorActionPreference = "Stop"
+$repo = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
+function Resolve-ZigExecutable {
+    $defaultWindowsZig = "C:\Users\Ady\Documents\toolchains\zig-master\current\zig.exe"
+    if ($env:OPENCLAW_ZIG_BIN -and $env:OPENCLAW_ZIG_BIN.Trim().Length -gt 0) {
+        if (-not (Test-Path $env:OPENCLAW_ZIG_BIN)) {
+            throw "OPENCLAW_ZIG_BIN is set but not found: $($env:OPENCLAW_ZIG_BIN)"
+        }
+        return $env:OPENCLAW_ZIG_BIN
+    }
+
+    $zigCmd = Get-Command zig -ErrorAction SilentlyContinue
+    if ($null -ne $zigCmd -and $zigCmd.Path) {
+        return $zigCmd.Path
+    }
+
+    if (Test-Path $defaultWindowsZig) {
+        return $defaultWindowsZig
+    }
+
+    throw "Zig executable not found. Set OPENCLAW_ZIG_BIN or ensure `zig` is on PATH."
+}
+
+function Read-UInt32LE {
+    param([byte[]] $Bytes, [int] $Offset)
+    return [System.BitConverter]::ToUInt32($Bytes, $Offset)
+}
+
+function Find-BytePatternIndex {
+    param(
+        [byte[]] $Bytes,
+        [byte[]] $Pattern
+    )
+    if ($Pattern.Length -eq 0 -or $Bytes.Length -lt $Pattern.Length) {
+        return -1
+    }
+    for ($i = 0; $i -le ($Bytes.Length - $Pattern.Length); $i++) {
+        $matched = $true
+        for ($j = 0; $j -lt $Pattern.Length; $j++) {
+            if ($Bytes[$i + $j] -ne $Pattern[$j]) {
+                $matched = $false
+                break
+            }
+        }
+        if ($matched) {
+            return $i
+        }
+    }
+    return -1
+}
+
+Set-Location $repo
+$zig = Resolve-ZigExecutable
+
+if (-not $SkipBuild) {
+    & $zig build baremetal-i386 -Doptimize=ReleaseFast --summary all
+    if ($LASTEXITCODE -ne 0) {
+        throw "zig build baremetal-i386 failed with exit code $LASTEXITCODE"
+    }
+}
+
+$artifactCandidates = @(
+    (Join-Path $repo "zig-out\bin\openclaw-zig-baremetal-i386.elf"),
+    (Join-Path $repo "zig-out/openclaw-zig-baremetal-i386.elf"),
+    (Join-Path $repo "zig-out\openclaw-zig-baremetal-i386.elf")
+)
+
+$artifact = $null
+foreach ($candidate in $artifactCandidates) {
+    if (Test-Path $candidate) {
+        $artifact = (Resolve-Path $candidate).Path
+        break
+    }
+}
+if ($null -eq $artifact) {
+    throw "i386 bare-metal artifact not found after build."
+}
+
+$bytes = [System.IO.File]::ReadAllBytes($artifact)
+if ($bytes.Length -lt 64) {
+    throw "artifact too small for ELF header: $artifact"
+}
+if ($bytes[0] -ne 0x7F -or $bytes[1] -ne 0x45 -or $bytes[2] -ne 0x4C -or $bytes[3] -ne 0x46) {
+    throw "artifact is not an ELF binary: $artifact"
+}
+if ($bytes[4] -ne 1) {
+    throw "artifact is not ELF32 (EI_CLASS != 1)"
+}
+if ($bytes[5] -ne 1) {
+    throw "artifact is not little-endian ELF (EI_DATA != 1)"
+}
+
+$multiboot2Magic = [byte[]] @(0xD6, 0x50, 0x52, 0xE8)
+$multibootOffset = Find-BytePatternIndex -Bytes $bytes -Pattern $multiboot2Magic
+if ($multibootOffset -lt 0) {
+    throw "multiboot2 header magic not found in i386 artifact"
+}
+if ($multibootOffset -ge 32768) {
+    throw "multiboot2 header was not found in first 32768 bytes (offset=$multibootOffset)"
+}
+if (($multibootOffset % 8) -ne 0) {
+    throw "multiboot2 header is not 8-byte aligned (offset=$multibootOffset)"
+}
+
+$architecture = Read-UInt32LE -Bytes $bytes -Offset ($multibootOffset + 4)
+if ($architecture -ne 0) {
+    throw "unsupported multiboot2 architecture value: $architecture (expected 0)"
+}
+
+Write-Output "BAREMETAL_I386_ARTIFACT=$artifact"
+Write-Output "BAREMETAL_I386_ELF32=True"
+Write-Output "BAREMETAL_I386_MULTIBOOT2=True"
+Write-Output "BAREMETAL_I386_SMOKE=pass"

--- a/scripts/baremetal-qemu-i386-smoke-check.ps1
+++ b/scripts/baremetal-qemu-i386-smoke-check.ps1
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: GPL-2.0-only
+param(
+    [switch] $SkipBuild,
+    [int] $TimeoutSeconds = 20
+)
+
+$ErrorActionPreference = "Stop"
+$repo = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
+function Resolve-ZigExecutable {
+    $defaultWindowsZig = "C:\Users\Ady\Documents\toolchains\zig-master\current\zig.exe"
+    if ($env:OPENCLAW_ZIG_BIN -and $env:OPENCLAW_ZIG_BIN.Trim().Length -gt 0) {
+        if (-not (Test-Path $env:OPENCLAW_ZIG_BIN)) {
+            throw "OPENCLAW_ZIG_BIN is set but not found: $($env:OPENCLAW_ZIG_BIN)"
+        }
+        return $env:OPENCLAW_ZIG_BIN
+    }
+
+    $zigCmd = Get-Command zig -ErrorAction SilentlyContinue
+    if ($null -ne $zigCmd -and $zigCmd.Path) {
+        return $zigCmd.Path
+    }
+
+    if (Test-Path $defaultWindowsZig) {
+        return $defaultWindowsZig
+    }
+
+    throw "Zig executable not found. Set OPENCLAW_ZIG_BIN or ensure `zig` is on PATH."
+}
+
+function Resolve-QemuExecutable {
+    $candidates = @(
+        "qemu-system-i386",
+        "qemu-system-i386.exe",
+        "qemu-system-x86_64",
+        "qemu-system-x86_64.exe",
+        "C:\Program Files\qemu\qemu-system-i386.exe",
+        "C:\Program Files\qemu\qemu-system-x86_64.exe"
+    )
+
+    foreach ($name in $candidates) {
+        $cmd = Get-Command $name -ErrorAction SilentlyContinue
+        if ($null -ne $cmd -and $cmd.Path) {
+            return $cmd.Path
+        }
+        if (Test-Path $name) {
+            return (Resolve-Path $name).Path
+        }
+    }
+
+    return $null
+}
+
+Set-Location $repo
+$zig = Resolve-ZigExecutable
+$qemu = Resolve-QemuExecutable
+
+if ($null -eq $qemu) {
+    Write-Output "BAREMETAL_I386_QEMU_AVAILABLE=False"
+    Write-Output "BAREMETAL_I386_QEMU_SMOKE=skipped"
+    return
+}
+
+$expectedExitCode = 85
+
+if (-not $SkipBuild) {
+    & $zig build baremetal-i386 -Doptimize=ReleaseFast -Dbaremetal-qemu-smoke=true --summary all
+    if ($LASTEXITCODE -ne 0) {
+        throw "zig build baremetal-i386 -Dbaremetal-qemu-smoke=true failed with exit code $LASTEXITCODE"
+    }
+}
+
+$artifactCandidates = @(
+    (Join-Path $repo "zig-out\bin\openclaw-zig-baremetal-i386.elf"),
+    (Join-Path $repo "zig-out/openclaw-zig-baremetal-i386.elf"),
+    (Join-Path $repo "zig-out\openclaw-zig-baremetal-i386.elf")
+)
+
+$artifact = $null
+foreach ($candidate in $artifactCandidates) {
+    if (Test-Path $candidate) {
+        $artifact = (Resolve-Path $candidate).Path
+        break
+    }
+}
+if ($null -eq $artifact) {
+    throw "i386 bare-metal artifact not found after build."
+}
+
+$stdoutPath = Join-Path $repo "release\qemu-i386-smoke-stdout.log"
+$stderrPath = Join-Path $repo "release\qemu-i386-smoke-stderr.log"
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $stdoutPath) | Out-Null
+if (Test-Path $stdoutPath) { Remove-Item -Force $stdoutPath }
+if (Test-Path $stderrPath) { Remove-Item -Force $stderrPath }
+
+$qemuArgs = @(
+    "-kernel", $artifact,
+    "-nographic",
+    "-no-reboot",
+    "-no-shutdown",
+    "-serial", "none",
+    "-monitor", "none",
+    "-device", "isa-debug-exit,iobase=0xf4,iosize=0x04"
+)
+
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $qemu
+$psi.UseShellExecute = $false
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.Arguments = (($qemuArgs | ForEach-Object {
+    if ("$_" -match '[\s"]') {
+        '"{0}"' -f (($_ -replace '"', '\"'))
+    } else {
+        "$_"
+    }
+}) -join ' ')
+
+$proc = New-Object System.Diagnostics.Process
+$proc.StartInfo = $psi
+[void]$proc.Start()
+$stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+$stderrTask = $proc.StandardError.ReadToEndAsync()
+
+if (-not $proc.WaitForExit($TimeoutSeconds * 1000)) {
+    try { $proc.Kill($true) } catch {}
+    throw "QEMU i386 bare-metal smoke timed out after $TimeoutSeconds seconds."
+}
+
+$proc.WaitForExit()
+$stdout = $stdoutTask.GetAwaiter().GetResult()
+$stderr = $stderrTask.GetAwaiter().GetResult()
+Set-Content -Path $stdoutPath -Value $stdout -Encoding Ascii
+Set-Content -Path $stderrPath -Value $stderr -Encoding Ascii
+$exitCode = $proc.ExitCode
+if ($exitCode -ne $expectedExitCode) {
+    $stderrTail = ""
+    if (Test-Path $stderrPath) {
+        $stderrTail = (Get-Content -Path $stderrPath -Tail 40 -ErrorAction SilentlyContinue) -join "`n"
+    }
+    throw "QEMU i386 bare-metal smoke failed: exit=$exitCode expected=$expectedExitCode`n$stderrTail"
+}
+
+Write-Output "BAREMETAL_I386_QEMU_AVAILABLE=True"
+Write-Output "BAREMETAL_I386_QEMU_BINARY=$qemu"
+Write-Output "BAREMETAL_I386_QEMU_ARTIFACT=$artifact"
+Write-Output "BAREMETAL_I386_QEMU_EXPECTED_EXIT_CODE=$expectedExitCode"
+Write-Output "BAREMETAL_I386_QEMU_EXIT_CODE=$exitCode"
+Write-Output "BAREMETAL_I386_QEMU_SMOKE=pass"

--- a/scripts/baremetal/i386_boot.S
+++ b/scripts/baremetal/i386_boot.S
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+.section .note.Xen,"a",@note
+.balign 4
+.long 4
+.long 4
+.long 18
+.asciz "Xen"
+.balign 4
+.long pvh_i386_start
+.balign 4
+
+.section .text.boot,"ax"
+.code32
+.balign 8
+
+.global multiboot32_start
+.type multiboot32_start,@function
+multiboot32_start:
+    jmp pvh_i386_start
+
+.global pvh_i386_start
+.type pvh_i386_start,@function
+pvh_i386_start:
+    cli
+    cld
+    movl $stack32_top, %esp
+    andl $-16, %esp
+    call _start
+
+1:
+    hlt
+    jmp 1b
+
+.section .bss.boot,"aw",@nobits
+.balign 16
+stack32:
+    .skip 131072
+stack32_top:

--- a/scripts/baremetal/i386_lld.ld
+++ b/scripts/baremetal/i386_lld.ld
@@ -1,0 +1,46 @@
+ENTRY(multiboot32_start)
+PHDRS
+{
+  note PT_NOTE FLAGS(4);
+  text PT_LOAD FLAGS(5);
+  data PT_LOAD FLAGS(6);
+}
+SECTIONS
+{
+  . = 0x00100000;
+
+  .note.Xen ALIGN(4) : {
+    KEEP(*(.note.Xen))
+  } :note
+
+  .multiboot ALIGN(8) : {
+    KEEP(*(.multiboot))
+  } :text
+
+  .text ALIGN(16) : {
+    *(.text.boot)
+    *(.text .text.*)
+  } :text
+
+  .rodata ALIGN(16) : {
+    *(.rodata .rodata.*)
+    *(.eh_frame .eh_frame.*)
+    *(.eh_frame_hdr)
+  } :text
+
+  .data ALIGN(16) : {
+    *(.data .data.*)
+    *(.data.rel.ro .data.rel.ro.*)
+  } :data
+
+  .bss ALIGN(4096) : {
+    *(.bss.boot)
+    *(.bss .bss.* COMMON)
+  } :data
+
+  /DISCARD/ : {
+    *(.debug*)
+    *(.comment)
+    *(.note.GNU-stack)
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added i386 bare-metal architecture support with new `zig build baremetal-i386` command for 32-bit x86 freestanding builds.
  * Added i386 smoke-check validation scripts for ELF32 artifact verification and QEMU boot testing.

* **Documentation**
  * Updated project documentation to reflect new i386 CPU architecture support and validation coverage.
  * Added dedicated architecture tracking documentation outlining i386 bare-metal scope and delivered features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->